### PR TITLE
validate_explain less in tests

### DIFF
--- a/t/draft3.t
+++ b/t/draft3.t
@@ -55,8 +55,11 @@ sub run_schema_test {
             schema => $test->{schema}
         );
         for ( @{ $test->{tests} } ) {
-            is !!$schema->check($_->{data}) => !!$_->{valid}, $_->{description} 
-                or diag join "\n", eval { @{$schema->validate_explain($_->{data})} };
+
+            # Test that the result from check is the same as what is in the spec.
+            # If the check should be true and the result is false, do validate_explain.
+            is !!$schema->check($_->{data}) => !!$_->{valid}, $_->{description}
+                or $_->{valid} and diag join "\n", @{$schema->validate_explain($_->{data})};
 
             diag join "\n", @{ $schema->validate_explain($_->{data}) || [] }
                 unless $_->{valid} or not $explain;

--- a/t/draft4.t
+++ b/t/draft4.t
@@ -51,8 +51,11 @@ sub run_schema_test {
     subtest $test->{description} => sub {
         my $schema = JSON::Schema::AsType->new( schema => $test->{schema});
         for ( @{ $test->{tests} } ) {
-            is !!$schema->check($_->{data}) => !!$_->{valid}, $_->{description} 
-                or diag join "\n", @{$schema->validate_explain($_->{data})};
+
+            # Test that the result from check is the same as what is in the spec.
+            # If the check should be true and the result is false, do validate_explain.
+            is !!$schema->check($_->{data}) => !!$_->{valid}, $_->{description}
+                or $_->{valid} and diag join "\n", @{$schema->validate_explain($_->{data})};
 
             diag join "\n", @{ $schema->validate_explain($_->{data}) }
                 unless $_->{valid} or not $explain;


### PR DESCRIPTION
When input is valid (but we expected it not to be), validate_explain is undef, so treating it as an arrayref will cause the tests to bail out.
