### PR TITLE
Decode ref schema with allow_nonref.

### DIFF
--- a/lib/JSON/Schema/AsType/Draft4.pm
+++ b/lib/JSON/Schema/AsType/Draft4.pm
@@ -52,7 +52,7 @@ __PACKAGE__->meta->add_method( '_keyword_$ref' => sub {
             message => sub { 
                 my $schema = $self->resolve_reference($ref);
 
-                join "\n", "ref schema is " . to_json($schema->schema), @{$schema->validate_explain($_)} 
+                join "\n", "ref schema is " . to_json($schema->schema, { allow_nonref => 1 }), @{$schema->validate_explain($_)} 
             }
         );
 } );


### PR DESCRIPTION
Fixes https://github.com/yanick/JSON-Schema-AsType/issues/14